### PR TITLE
write headers to response once

### DIFF
--- a/web.js
+++ b/web.js
@@ -2,25 +2,26 @@ var http = require('http');
 var xkcd = require('xkcd-imgs');
 
 var server = http.createServer(function (request, resp) {
- 	resp.writeHead(200, {'Content-Type': 'application/json'});
-  var headers = {};
+    var headers = {};
+    headers['Content-Type'] = 'application/json';
     headers["Access-Control-Allow-Origin"] = "*";
     headers["Access-Control-Allow-Methods"] = "POST, GET, PUT, DELETE, OPTIONS";
     headers["Access-Control-Allow-Credentials"] = true;
     headers["Access-Control-Max-Age"] = '86400'; // 24 hours
     headers["Access-Control-Allow-Headers"] = "X-Requested-With, Access-Control-Allow-Origin, X-HTTP-Method-Override, Content-Type, Authorization, Accept";
-    // respond to the request
-    resp.writeHead(200, headers);  
-    
-    xkcd.img(function(err,res){
-        if(!err){
-           resp.end(JSON.stringify(res));
-        } else {
-            resp.end(JSON.stringify({error:err.message}));
+    // send headers
+    resp.writeHead(200, headers);
+
+    xkcd.img(function(err, res){
+        if(err){
+            return resp.end(JSON.stringify({ error: err.message }));
         }
+        return resp.end(JSON.stringify(res));
     });
 });
 
 var port = process.env.PORT || 3000;
-server.listen(port);
-console.log("Server running at http://127.0.0.1/ on port " + port);
+server.listen(port, function() {
+    console.log("Server running at http://127.0.0.1/ on port " + port);
+});
+


### PR DESCRIPTION
From Node.js API documentation
(https://nodejs.org/api/all.html#all_response_writehead_statuscode_statusmessage_headers):

> response.writeHead(statusCode[, statusMessage][, headers])#
> 
> This method must only be called once on a message

Also:
- code refactored to maintain consistency across script and
  with most Node.js applications
